### PR TITLE
moves semicolons out of strings

### DIFF
--- a/src/generators/enumType.js
+++ b/src/generators/enumType.js
@@ -2,7 +2,7 @@ import writeText from '../writeText';
 
 export default function(definition){
   return writeText(t => {
-    t.line(`import { GraphQLEnumType } from 'graphql/type'`);
+    t.line(`import { GraphQLEnumType } from 'graphql/type';`);
     t.line(``);
     t.block(`const ${definition.name}Type = new GraphQLEnumType({`,e => {
       e.line(`name: '${definition.name}',`);
@@ -14,6 +14,6 @@ export default function(definition){
       },`}`);
     },`});`);
     t.line(``);
-    t.line(`export default ${definition.name}Type`);
+    t.line(`export default ${definition.name}Type;`);
   });
 }

--- a/src/generators/interfaceDeps.js
+++ b/src/generators/interfaceDeps.js
@@ -7,7 +7,7 @@ export default function renderInterfaceDeps(definition){
 
   let str = '';
   interfaceDeps.forEach(dep => {
-    str += `import ${dep}InterfaceType from '../interfaces/${dep};'\n`
+    str += `import ${dep}InterfaceType from '../interfaces/${dep}';\n`
   });
   return str
 }

--- a/src/generators/primitiveDeps.js
+++ b/src/generators/primitiveDeps.js
@@ -31,7 +31,7 @@ function extractPrimitiveDepsIntoSet(type,set){
     set.add('GraphQLList');
   }
 
-  return set;  
+  return set;
 }
 
 export default function renderPrimitiveDeps(definition){
@@ -59,7 +59,7 @@ export default function renderPrimitiveDeps(definition){
   let str = '';
   str += `import {\n`
   str += `\t${Array.from(primitiveDeps).join(',\n\t')}\n`
-  str += `} from 'graphql/type;'\n`
+  str += `} from 'graphql/type';\n`
   return str
 }
 

--- a/src/generators/userDeps.js
+++ b/src/generators/userDeps.js
@@ -20,10 +20,10 @@ export default function renderUserDeps(definition){
   if(userDeps.has(definition.name)){
     userDeps.delete(definition.name);
   }
-  
+
   let str = '';
   userDeps.forEach(dep => {
-    str += `import ${dep}Type from './${dep};'\n`
+    str += `import ${dep}Type from './${dep}';\n`
   });
   return str
 }


### PR DESCRIPTION
@christensenemc awesome tool for quickly getting started writing graphql schemas.

Came across this small issue. The generated import statement added ; inside strings instead of outside so

``` javascript
{ GraphQLEnumType } from 'graphql/type;'
```

instead of 

``` javascript
{ GraphQLEnumType } from 'graphql/type';
```

I hope this fixes it. 

Was unsure if you want the generate `lib` files a part of a pull request as well. Let me know. 
